### PR TITLE
[Recorder] feat: add ip-cache

### DIFF
--- a/recorder/src/main/java/at/htl/franklyn/boundary/SavesResource.java
+++ b/recorder/src/main/java/at/htl/franklyn/boundary/SavesResource.java
@@ -1,10 +1,13 @@
 package at.htl.franklyn.boundary;
 
+import at.htl.franklyn.control.ExamineeCacheRepository;
 import at.htl.franklyn.entity.Examinee;
 import at.htl.franklyn.services.ExamineesService;
 import at.htl.franklyn.services.ScreenshotService;
 
+import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -17,34 +20,38 @@ import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
-public class Saves {
+public class SavesResource {
     @RestClient
     ExamineesService examineesService;
     @RestClient
     ScreenshotService screenshotService;
 
+    @Inject
+    ExamineeCacheRepository examineeCacheRepository;
+
     @ConfigProperty(name = "timestamp.pattern")
     String timestampPattern;
 
+    @ConfigProperty(name = "openbox.port")
+    int openboxPort;
+
     @Scheduled(every = "{update.interval}")
     public void update(){
-        List<Examinee> examinees = examineesService.getExaminees();
+        // all examinees here should be connected
+        Map<String, String> ipAddresses = examineeCacheRepository.getAllCachedExaminees();
 
-        for(Examinee examine: examinees){
-            if(!examine.isConnected()){
-                continue;
-            }
-
+        for(String examinee : ipAddresses.keySet()){
             try {
-                File directory = new File(String.format("screenshots/%s-%s", examine.getIpAddress(), examine.getUserName()));
+                File directory = new File(String.format("screenshots/%s-%s", ipAddresses.get(examinee), examinee));
 
                 if(!directory.exists()){
                     directory.mkdirs();
                 }
 
                 screenshotService = RestClientBuilder.newBuilder()
-                        .baseUri(URI.create(String.format("http://%s:8081", examine.getIpAddress())))
+                        .baseUri(URI.create(String.format("http://%s:%d", ipAddresses.get(examinee), openboxPort)))
                         .build(ScreenshotService.class);
 
                 ByteArrayInputStream bis = new ByteArrayInputStream(screenshotService.getScreenshot());
@@ -54,7 +61,7 @@ public class Saves {
                         "png",
                         new File(String.format("%s/%s-%s.png",
                             directory.getPath(), 
-                            examine.getIpAddress(), 
+                            ipAddresses.get(examinee),
                             new SimpleDateFormat(timestampPattern).format(new Date())))
                 );
             } catch (IOException e) {

--- a/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheBean.java
+++ b/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheBean.java
@@ -1,0 +1,53 @@
+package at.htl.franklyn.control;
+
+import at.htl.franklyn.entity.Examinee;
+import at.htl.franklyn.services.ExamineesService;
+import at.htl.franklyn.services.PingService;
+import at.htl.franklyn.services.ScreenshotService;
+import io.quarkus.logging.Log;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+
+@ApplicationScoped
+public class ExamineeCacheBean {
+    @RestClient
+    ExamineesService examineesService;
+
+    @ConfigProperty(name = "openbox.port", defaultValue = "8081")
+    int openboxPort;
+
+    @Inject
+    ExamineeCacheRepository examineeCacheRepository;
+
+    @Scheduled(every = "{cache-update.interval}")
+    public void updateCache() {
+        List<Examinee> examinees = examineesService.getExaminees();
+        boolean hasChanged = examineeCacheRepository.updateCache(examinees);
+
+        if(hasChanged) {
+            for(Examinee examinee : examineeCacheRepository.getAllActiveExaminees()) {
+                for(String ip : examinee.getIpAddresses()) {
+                    PingService pingService = RestClientBuilder.newBuilder()
+                            .baseUri(URI.create(String.format("http://%s:%d", ip, openboxPort)))
+                            .build(PingService.class);
+
+                    pingService.sendPing()
+                            .toCompletableFuture()
+                            .orTimeout(1000, TimeUnit.MILLISECONDS)
+                            .thenAcceptAsync((response) -> {
+                                examineeCacheRepository.saveToCache(examinee.getUserName(), ip);
+                            });
+                }
+            }
+        }
+    }
+}

--- a/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheBean.java
+++ b/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheBean.java
@@ -3,8 +3,6 @@ package at.htl.franklyn.control;
 import at.htl.franklyn.entity.Examinee;
 import at.htl.franklyn.services.ExamineesService;
 import at.htl.franklyn.services.PingService;
-import at.htl.franklyn.services.ScreenshotService;
-import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -15,7 +13,6 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 
 @ApplicationScoped
 public class ExamineeCacheBean {
@@ -44,7 +41,7 @@ public class ExamineeCacheBean {
                             .toCompletableFuture()
                             .orTimeout(1000, TimeUnit.MILLISECONDS)
                             .thenAcceptAsync((response) -> {
-                                examineeCacheRepository.saveToCache(examinee.getUserName(), ip);
+                                examineeCacheRepository.saveToCache(examinee.getUsername(), ip);
                             });
                 }
             }

--- a/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheRepository.java
+++ b/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheRepository.java
@@ -3,7 +3,6 @@ package at.htl.franklyn.control;
 import at.htl.franklyn.entity.Examinee;
 import jakarta.enterprise.context.ApplicationScoped;
 
-import javax.crypto.ExemptionMechanism;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,8 +21,8 @@ public class ExamineeCacheRepository {
 
         for(Examinee newExaminee : examinees) {
             // Remove examinee from cache in case any attributes have changed
-            if(!newExaminee.equals(allExaminees.get(newExaminee.getUserName()))) {
-                cachedExaminees.remove(newExaminee.getUserName());
+            if(!newExaminee.equals(allExaminees.get(newExaminee.getUsername()))) {
+                cachedExaminees.remove(newExaminee.getUsername());
                 hasChanged = true;
             }
         }
@@ -31,7 +30,7 @@ public class ExamineeCacheRepository {
         // clear examinees and refill
         allExaminees.clear();
         for(Examinee newExaminee : examinees) {
-            allExaminees.put(newExaminee.getUserName(), newExaminee);
+            allExaminees.put(newExaminee.getUsername(), newExaminee);
         }
 
         return hasChanged;

--- a/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheRepository.java
+++ b/recorder/src/main/java/at/htl/franklyn/control/ExamineeCacheRepository.java
@@ -1,0 +1,52 @@
+package at.htl.franklyn.control;
+
+import at.htl.franklyn.entity.Examinee;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import javax.crypto.ExemptionMechanism;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@ApplicationScoped
+public class ExamineeCacheRepository {
+    // Key: username
+    ConcurrentMap<String, Examinee> allExaminees = new ConcurrentHashMap<>();
+
+    // Key: username, Value: ip address
+    ConcurrentMap<String, String> cachedExaminees = new ConcurrentHashMap<>();
+
+    public boolean updateCache(List<Examinee> examinees) {
+        boolean hasChanged = examinees.size() != allExaminees.size();
+
+        for(Examinee newExaminee : examinees) {
+            // Remove examinee from cache in case any attributes have changed
+            if(!newExaminee.equals(allExaminees.get(newExaminee.getUserName()))) {
+                cachedExaminees.remove(newExaminee.getUserName());
+                hasChanged = true;
+            }
+        }
+
+        // clear examinees and refill
+        allExaminees.clear();
+        for(Examinee newExaminee : examinees) {
+            allExaminees.put(newExaminee.getUserName(), newExaminee);
+        }
+
+        return hasChanged;
+    }
+
+    public void saveToCache(String username, String ipAddress) {
+        this.cachedExaminees.put(username, ipAddress);
+    }
+
+    public List<Examinee> getAllActiveExaminees() {
+        return allExaminees.values().stream().filter(Examinee::isConnected).toList();
+    }
+
+    // Key: username, value: ip address
+    public Map<String, String> getAllCachedExaminees() {
+        return cachedExaminees;
+    }
+}

--- a/recorder/src/main/java/at/htl/franklyn/entity/Examinee.java
+++ b/recorder/src/main/java/at/htl/franklyn/entity/Examinee.java
@@ -22,11 +22,11 @@ public class Examinee {
         this.isConnected = isConnected;
     }
 
-    public String getUserName() {
+    public String getUsername() {
         return username;
     }
 
-    public void setUserName(String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 

--- a/recorder/src/main/java/at/htl/franklyn/entity/Examinee.java
+++ b/recorder/src/main/java/at/htl/franklyn/entity/Examinee.java
@@ -1,33 +1,41 @@
 package at.htl.franklyn.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Arrays;
+import java.util.Objects;
+
 public class Examinee {
-    private String userName;
-    private String ipAddress;
+    @JsonProperty("username")
+    private String username;
+    @JsonProperty("ipAddresses")
+    private String[] ipAddresses;
+    @JsonProperty("connected")
     private boolean isConnected;
 
     public Examinee() {
     }
 
-    public Examinee(String userName, String ipAddress, boolean isConnected) {
-        this.userName = userName;
-        this.ipAddress = ipAddress;
+    public Examinee(String username, String[] ipAddresses, boolean isConnected) {
+        this.username = username;
+        this.ipAddresses = ipAddresses;
         this.isConnected = isConnected;
     }
 
     public String getUserName() {
-        return userName;
+        return username;
     }
 
-    public void setUserName(String userName) {
-        this.userName = userName;
+    public void setUserName(String username) {
+        this.username = username;
     }
 
-    public String getIpAddress() {
-        return ipAddress;
+    public String[] getIpAddresses() {
+        return ipAddresses;
     }
 
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
+    public void setIpAddresses(String[] ipAddresses) {
+        this.ipAddresses = ipAddresses;
     }
 
     public boolean isConnected() {
@@ -35,6 +43,14 @@ public class Examinee {
     }
 
     public void setConnected(boolean connected) {
-        isConnected = connected;
+        this.isConnected = connected;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Examinee examinee = (Examinee) o;
+        return isConnected == examinee.isConnected && Objects.equals(username, examinee.username) && Arrays.equals(ipAddresses, examinee.ipAddresses);
     }
 }

--- a/recorder/src/main/java/at/htl/franklyn/services/PingService.java
+++ b/recorder/src/main/java/at/htl/franklyn/services/PingService.java
@@ -1,0 +1,16 @@
+package at.htl.franklyn.services;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import java.util.concurrent.CompletionStage;
+
+@Path("/screenshot")
+@RegisterRestClient()
+public interface PingService {
+    @GET
+    @Path("/health")
+    CompletionStage<Response> sendPing();
+}

--- a/recorder/src/main/resources/application.properties
+++ b/recorder/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 quarkus.rest-client.server-address.url=http://localhost:8080
 quarkus.http.port=8083
 update.interval = 10s
+cache-update.interval = 8s
 openbox.port = 8081
 timestamp.pattern = dd-MM-yyyy-HH:mm:ss
 


### PR DESCRIPTION
Add a small and simple ip cache to the recorder.

The task of this ip cache is:
- storing all examinees retrieved from the server
- storing the single ip asocciated with each examinee
  - this is the essential task since the server can now give us multiple ip addresses for each client
- frequently update