### PR TITLE
feat [CI/CD]: build frontend outside of Dockerfile

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -66,10 +66,21 @@ jobs:
           if test "${{ github.ref_name }}" = "main"; then tag="latest"; else tag="dev"; fi
           echo "IMAGE_TAG=${tag}" >> "$GITHUB_ENV"
 
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+          cache: 'npm'
+          cache-dependency-path: 'instructor-client/package-lock.json'
+
+      - name: Build instructor-client
+        run: |
+          ./cicd/build-instructor-client.sh
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./instructor-client
+          context: ./
           file: ./instructor-client/docker/Dockerfile
           platforms: linux/amd64, linux/arm64
           push: true

--- a/cicd/build-instructor-client.sh
+++ b/cicd/build-instructor-client.sh
@@ -4,7 +4,7 @@ set -e
 
 pushd instructor-client
   npm install
-  npx ng build --configuration production instructor-client
+  npx ng build --configuration production --base-href /instructor/ instructor-client
 popd
 
 mkdir -p dist/instructor-client

--- a/instructor-client/docker/Dockerfile
+++ b/instructor-client/docker/Dockerfile
@@ -1,13 +1,4 @@
-FROM node:21 AS builder
-
-WORKDIR /opt/franklyn
-
-COPY . .
-
-RUN npm install
-RUN npx ng build --configuration production --base-href /instructor/ instructor-client
-
 FROM nginx:1.25.4
 
-COPY --from=builder /opt/franklyn/dist/instructor-client/browser/* /usr/share/nginx/html/instructor/
-COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY ./instructor-client/docker/nginx.conf /etc/nginx/nginx.conf
+COPY ./dist/instructor-client/* /usr/share/nginx/html/instructor/


### PR DESCRIPTION
Since the frontend "compiles" down to js and html and both of them are platform independent we can build the instructor-client outside of the container instead of inside (which is currently the case).
This should significantly reduce the amount of time needed for our build-docker-images action to complete.